### PR TITLE
Print the stack trace when a plugin fails to load due to an exception thrown from its constructor

### DIFF
--- a/src/main/java/net/lenni0451/spm/utils/PluginUtils.java
+++ b/src/main/java/net/lenni0451/spm/utils/PluginUtils.java
@@ -237,6 +237,7 @@ public class PluginUtils {
             throw new IllegalStateException(I18n.t("pm.pluginutils.loadPlugin.missingDependency"));
         } catch (InvalidPluginException e) {
 //            throw new IllegalStateException("Invalid plugin file");
+            e.printStackTrace();
             throw new IllegalStateException(I18n.t("pm.pluginutils.loadPlugin.invalidPluginFile"));
         }
 


### PR DESCRIPTION
I've been having issues using this plugin manager for development where the plugin fails to load due to an exception being thrown from the plugin's constructor. SpigotPluginManager would swallow the exception and simply report `PM | Could not load the plugin <name>. (Invalid plugin file)`, which did not provide any useful information as to where the error occurred.

I added a simple call to `printStackTrace()` in the `loadPlugin()` method to fix this. There are some other exceptions nearby that don't print a stack trace either, but I don't have any tests for them, and further modifications are outside the scope of my current use case.
