### PR TITLE
Add handling for filename quotes in `/pm download` and add tab completion for filenames

### DIFF
--- a/src/main/java/net/lenni0451/spm/commands/subs/Download_Sub.java
+++ b/src/main/java/net/lenni0451/spm/commands/subs/Download_Sub.java
@@ -30,6 +30,7 @@ public class Download_Sub implements ISubCommandMultithreaded {
         	for(int i = 3; i < args.length; i++) {
         		filename += args[i];
         	}
+        	filename = filename.substring(1, filename.length() - 1);
         }
         filename = filename.replace("/", "").replace("\\", "");
 

--- a/src/main/java/net/lenni0451/spm/commands/subs/Download_Sub.java
+++ b/src/main/java/net/lenni0451/spm/commands/subs/Download_Sub.java
@@ -31,10 +31,10 @@ public class Download_Sub implements ISubCommandMultithreaded {
         		filename += args[i];
         	}
         }
-        args[2] = args[2].replace("/", "").replace("\\", "");
+        filename = filename.replace("/", "").replace("\\", "");
 
         String url = args[1];
-        File file = new File(PluginManager.getInstance().getPluginUtils().getPluginsDirectory(), args[2] + (args[2].toLowerCase().endsWith(".jar") ? "" : ".jar"));
+        File file = new File(PluginManager.getInstance().getPluginUtils().getPluginsDirectory(), filename + (filename.toLowerCase().endsWith(".jar") ? "" : ".jar"));
         if (args[0].equalsIgnoreCase("direct")) {
             try {
                 DownloadUtils.downloadPlugin(url, file);
@@ -123,8 +123,9 @@ public class Download_Sub implements ISubCommandMultithreaded {
             }
         }
         if (args.length == 2 && (args[0].equalsIgnoreCase("direct") || args[0].equalsIgnoreCase("spigot"))) {
-	        try {
-	            for (File file : PluginManager.getInstance().getPluginUtils().getPluginsDirectory().listFiles()) {
+        	File[] files = PluginManager.getInstance().getPluginUtils().getPluginsDirectory().listFiles();
+        	if (files != null) {
+	            for (File file : files) {
 	            	if (file.isFile() && file.getName().toLowerCase().endsWith(".jar")) {
 	            		String filename= file.getName();
 	            		if (filename.contains(" ")) {
@@ -133,8 +134,7 @@ public class Download_Sub implements ISubCommandMultithreaded {
 	            		tabs.add(filename);
 	            	}
 	            }
-	        } catch(Throwable ignored) {
-	        }
+        	}
         }
     }
 

--- a/src/main/java/net/lenni0451/spm/commands/subs/Download_Sub.java
+++ b/src/main/java/net/lenni0451/spm/commands/subs/Download_Sub.java
@@ -18,13 +18,19 @@ public class Download_Sub implements ISubCommandMultithreaded {
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        if (args.length != 3) return false;
+        if (args.length < 3) return false;
         if (!args[0].equalsIgnoreCase("direct") && !args[0].equalsIgnoreCase("spigot")) return false;
         if (!sender.hasPermission("pluginmanager.commands.download." + args[0].toLowerCase())) {
             Logger.sendPermissionMessage(sender);
             return true;
         }
 
+        String filename = args[2];
+        if(args.length > 3 && filename.startsWith("\"") && args[args.length-1].endsWith("\"")) {
+        	for(int i = 3; i < args.length; i++) {
+        		filename += args[i];
+        	}
+        }
         args[2] = args[2].replace("/", "").replace("\\", "");
 
         String url = args[1];
@@ -115,6 +121,20 @@ public class Download_Sub implements ISubCommandMultithreaded {
                 urlPart = urlPart.substring(0, urlPart.lastIndexOf("."));
                 tabs.add(urlPart + ".jar");
             }
+        }
+        if (args.length == 2 && (args[0].equalsIgnoreCase("direct") || args[0].equalsIgnoreCase("spigot"))) {
+	        try {
+	            for (File file : PluginManager.getInstance().getPluginUtils().getPluginsDirectory().listFiles()) {
+	            	if (file.isFile() && file.getName().toLowerCase().endsWith(".jar")) {
+	            		String filename= file.getName();
+	            		if (filename.contains(" ")) {
+	            			filename = "\"" + filename + "\"";
+	            		}
+	            		tabs.add(filename);
+	            	}
+	            }
+	        } catch(Throwable ignored) {
+	        }
         }
     }
 


### PR DESCRIPTION
- `/pm download` is incapable of handling file names with spaces. This allows using quotes to accept those filenames
- Adds tab completing filenames when the user has `/pm download <url> ` entered. 