### PR TITLE
Fixed IllegalStateException being thrown while loading new Plugin

### DIFF
--- a/src/main/java/net/lenni0451/spm/utils/PluginUtils.java
+++ b/src/main/java/net/lenni0451/spm/utils/PluginUtils.java
@@ -255,7 +255,7 @@ public class PluginUtils {
                 Class.forName(PAPER_ENTRYPOINT_HANDLER);
                 Class<?> PaperSupport = Class.forName(PAPER_SUPPORT);
                 targetPlugin = (Plugin) PaperSupport.getDeclaredMethod("loadPlugin", File.class).invoke(null, targetFile.get());
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException | IllegalStateException e) {
                 targetPlugin = this.getPluginManager().loadPlugin(targetFile.get());
             }
         } catch (UnknownDependencyException e) {


### PR DESCRIPTION
To check if the plugin correctly downloads the newest version of itself and loads, I compiled the newest version of the plugin but with maven_version set to 2.8.0 in gradle.propeties.
While trying loading the plugin, it will throw an IlliegalStateException in PluginUtils.java:255, which will get caught and another exception will be thrown in PluginUtils.java:270.

This also happens, if I download your newest, compiled version and changed the version in plugin.yml.

With also catching the IllegalStateException, the plugin will load just fine and function correctly.

Maybe the plugin works just fine, and I tested it wrong, just let me know.
@Lenni0451 